### PR TITLE
fix issue with file path forward slash in Windows

### DIFF
--- a/optimize.py
+++ b/optimize.py
@@ -17,6 +17,8 @@ from stable_baselines.common.policies import MlpLnLstmPolicy
 from stable_baselines.common.vec_env import DummyVecEnv
 from stable_baselines import PPO2
 
+from pathlib import Path
+
 from env.BitcoinTradingEnv import BitcoinTradingEnv
 from util.indicators import add_indicators
 
@@ -78,7 +80,7 @@ def optimize_agent(trial):
 
     model_params = optimize_ppo2(trial)
     model = PPO2(MlpLnLstmPolicy, train_env, verbose=0, nminibatches=1,
-                 tensorboard_log="./tensorboard", **model_params)
+                 tensorboard_log=Path("./tensorboard").name, **model_params)
 
     last_reward = -np.finfo(np.float16).max
     evaluation_interval = int(len(train_df) / n_evaluations)

--- a/train.py
+++ b/train.py
@@ -7,6 +7,8 @@ from stable_baselines.common.policies import MlpLnLstmPolicy
 from stable_baselines.common.vec_env import SubprocVecEnv, DummyVecEnv
 from stable_baselines import A2C, ACKTR, PPO2
 
+from pathlib import Path
+
 from env.BitcoinTradingEnv import BitcoinTradingEnv
 from util.indicators import add_indicators
 
@@ -52,7 +54,7 @@ model_params = {
 
 if curr_idx == -1:
     model = PPO2(MlpLnLstmPolicy, train_env, verbose=0, nminibatches=1,
-            tensorboard_log="./tensorboard", **model_params)
+            tensorboard_log=Path("./tensorboard").name, **model_params)
 else:
     model = PPO2.load('./agents/ppo2_' + reward_strategy + '_' + str(curr_idx) + '.pkl', env=train_env)
 


### PR DESCRIPTION
The Unix / Macos / Linux file path delimiter forward slash causes problems with some Python code. Most libraries seem to sanitize (but not all I guess).

These are the two places that caused an issue for me - there may be others, I haven't yet run a full optimize - train - test cycle