### PR TITLE
Add do_benchmark flag to speed up optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ research/results
 **/__pycache__
 *.pkl
 *.db
+.idea

--- a/env/BitcoinTradingEnv.py
+++ b/env/BitcoinTradingEnv.py
@@ -33,22 +33,23 @@ class BitcoinTradingEnv(gym.Env):
         self.stationary_df = log_and_difference(
             self.df, ['Open', 'High', 'Low', 'Close', 'Volume BTC', 'Volume USD'])
 
-        benchmarks = kwargs.get('benchmarks', [])
-        self.benchmarks = [
-            {
-                'label': 'Buy and HODL',
-                'values': buy_and_hodl(self.df['Close'], initial_balance, commission)
-            },
-            {
-                'label': 'RSI Divergence',
-                'values': rsi_divergence(self.df['Close'], initial_balance, commission)
-            },
-            {
-                'label': 'SMA Crossover',
-                'values': sma_crossover(self.df['Close'], initial_balance, commission)
-            },
-            *benchmarks,
-        ]
+        do_benchmark = kwargs.get('do_benchmark', True)
+        self.benchmarks = kwargs.get('benchmarks', [])
+        if do_benchmark:
+            self.benchmarks.append([
+                {
+                    'label': 'Buy and HODL',
+                    'values': buy_and_hodl(self.df['Close'], initial_balance, commission)
+                },
+                {
+                    'label': 'RSI Divergence',
+                    'values': rsi_divergence(self.df['Close'], initial_balance, commission)
+                },
+                {
+                    'label': 'SMA Crossover',
+                    'values': sma_crossover(self.df['Close'], initial_balance, commission)
+                }
+            ])
 
         self.forecast_len = kwargs.get('forecast_len', 10)
         self.confidence_interval = kwargs.get('confidence_interval', 0.95)

--- a/optimize.py
+++ b/optimize.py
@@ -56,6 +56,7 @@ def optimize_envs(trial):
         'reward_func': reward_strategy,
         'forecast_len': int(trial.suggest_loguniform('forecast_len', 1, 200)),
         'confidence_interval': trial.suggest_uniform('confidence_interval', 0.7, 0.99),
+        'do_benchmark': False
     }
 
 


### PR DESCRIPTION
Benchmarks aren't used when optimizing, so it makes sense to speed up that phase by disabling benchmark generation. This change will allow for that without affecting normal operation.

Changes:
* Add do_benchmark flag to BitcoinEnv
* Set do_benchmark flag to False when optimizing
* Change benchmark array logic to cater for do_benchmark flag